### PR TITLE
Fix: Python 3 compatibility

### DIFF
--- a/bottle_inject.py
+++ b/bottle_inject.py
@@ -153,6 +153,7 @@ class Injector(object):
             kwonlyargs, kwonlydefaults, annotations = [], {}, {}
 
         defaults = defaults or ()
+        kwonlydefaults = kwonlydefaults or {}
 
         injection_points = {}
 


### PR DESCRIPTION
Current code does not work on Python 3 because `kwonlydefaults` returned by `getfullargspec` are set to `None` if they are not present in function arguments, eventually rising an `AttributeError`:
```
    for arg, value in kwonlydefaults.items():
AttributeError: 'NoneType' object has no attribute 'items'
```
The suggested PR resolves the issue by setting an empty dictionary to handle this case.